### PR TITLE
Add zero-downtime deployment with configurable drain timeout

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,136 @@
+name: Build, Test & Push
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      drain_timeout:
+        description: 'Drain timeout in seconds (default: 600 = 10 minutes for production)'
+        required: false
+        default: '600'
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: registry.nordquant.com
+  IMAGE_NAME: dbt-bootcamp-setup
+
+jobs:
+  build-test-push:
+    name: Build, Test & Push Docker Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=moby/buildkit:latest
+            network=host
+
+      - name: Log in to Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false
+          load: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:test
+          cache-from: |
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-to: type=inline
+
+      - name: Test Docker image
+        run: |
+          # Start the app
+          docker run -d --name test-app \
+            -p 8501:8501 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:test
+
+          # Wait for app to be healthy
+          echo "Waiting for app to be healthy..."
+          for i in {1..30}; do
+            if docker inspect --format='{{.State.Health.Status}}' test-app 2>/dev/null | grep -q "healthy"; then
+              echo "App is healthy!"
+              break
+            fi
+            if [ $i -eq 30 ]; then
+              echo "App failed to become healthy"
+              docker logs test-app
+              exit 1
+            fi
+            echo "Waiting... ($i/30)"
+            sleep 2
+          done
+
+          # Test health endpoint
+          echo "Testing health endpoint..."
+          curl -f http://localhost:8501/healthz || exit 1
+
+          # Test main page contains "Snowflake"
+          echo "Testing main page..."
+          curl -f http://localhost:8501/ | grep -q "Snowflake" || exit 1
+
+          echo "All tests passed!"
+
+          # Cleanup
+          docker stop test-app
+          docker rm test-app
+
+      - name: Push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+          cache-from: |
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+
+      - name: Image pushed successfully
+        run: |
+          echo "Image pushed to ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          echo "Image also tagged as ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}"
+
+      - name: Deploy to production server
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: 22
+          timeout: 20m
+          envs: DRAIN_TIMEOUT
+          script: |
+            set -e
+            cd /home/zoltanctoth/base-infra
+
+            echo "Pulling latest image..."
+            docker compose pull dbt-bootcamp-setup
+
+            echo "Starting zero-downtime deployment..."
+            export DRAIN_TIMEOUT=${{ inputs.drain_timeout || '600' }}
+            ./scripts/redeploy_dbtsetup.sh
+
+            echo "Deployment completed successfully!"

--- a/README.md
+++ b/README.md
@@ -1,44 +1,146 @@
-# dbt Snowflake Setup Helper
+# dbt Bootcamp Setup - Snowflake Importer
 
-A Streamlit app to help set up Snowflake accounts and import course resources for the dbt bootcamp.
+A Streamlit web application that automates Snowflake account setup for the dbt Zero to Hero Udemy course. This app helps students quickly configure their Snowflake environment with the necessary databases, users, roles, and sample data.
 
-## Quick Start
-
-### Local Development
-```bash
-# Option 1: Direct streamlit command
-streamlit run
-
-# Option 2: Using the runner script
-python run.py
-
-# Option 3: Specify the file explicitly
-streamlit run streamlit_app.py
-```
-
-### Streamlit Cloud Deployment
-1. Push this repository to GitHub
-2. Connect to Streamlit Cloud
-3. The app will automatically detect `streamlit_app.py` and deploy
+**Now with zero-downtime deployments!**
 
 ## Features
 
-- **Step 1:** Automatic RSA keypair generation and download
-- **Step 2:** Snowflake account setup and data import
-- **Security:** Encrypted private keys with passphrase protection
-- **User-friendly:** Step-by-step guided process
+- 🚀 Automated Snowflake account setup
+- 👤 Creates dbt user with appropriate roles and permissions
+- 🗄️ Sets up AIRBNB database with RAW and DEV schemas
+- 📊 Imports sample AirBnB data from S3
+- ✅ Validates data import with row count checks
+- 🎯 Creates REPORTER role for dashboard access
+
+## Quick Start
+
+### Running Locally with Python
+
+```bash
+# Install dependencies (requires Python 3.13)
+uv sync
+
+# Run the Streamlit app
+uv run streamlit run streamlit_app.py
+```
+
+### Running with Docker
+
+```bash
+# Using docker-compose (easiest)
+docker-compose up -d
+
+# Or pull from registry
+docker run -p 8501:8501 registry.nordquant.com/dbt-bootcamp-setup:latest
+```
+
+Access the app at http://localhost:8501
+
+## Development
+
+### Prerequisites
+
+- Python 3.13
+- [uv](https://github.com/astral-sh/uv) package manager
+- Docker (for containerized deployment)
+
+### Setup
+
+```bash
+# Install dependencies
+uv sync
+
+# Install dev dependencies
+uv sync --extra dev
+
+# Run tests
+docker-compose --profile test up test --exit-code-from test
+```
+
+### Project Structure
+
+```
+.
+├── streamlit_app.py          # Main Streamlit application
+├── course-resources.md       # SQL setup commands (from course)
+├── pyproject.toml           # Python dependencies (uv format)
+├── Dockerfile               # Multi-stage Docker build
+├── docker-compose.yml       # Docker compose with test profile
+├── build_push.sh           # Build script for multi-platform images
+└── DOCKER.md               # Docker documentation
+```
+
+## Docker
+
+This project uses a multi-stage Docker build optimized for caching:
+
+- **Base**: Python 3.13 Alpine with build tools
+- **Dependencies**: Python packages (cached when dependencies unchanged)
+- **Final**: Application code (rebuilt on code changes)
+
+### Building and Pushing
+
+```bash
+# Build and push for both amd64 and arm64
+./build_push.sh
+
+# Build only (no push)
+./build_push.sh --build-only --platform linux/arm64
+
+# Custom tag
+./build_push.sh --tag v1.0.0
+
+# See all options
+./build_push.sh --help
+```
+
+See [DOCKER.md](DOCKER.md) for detailed Docker documentation.
 
 ## Configuration
 
-The app uses `.streamlit/config.toml` for configuration:
-- Auto-reload on file changes (`runOnSave = true`)
-- Streamlit Cloud compatible settings
-- Custom theme (optional)
+The app creates the following Snowflake resources:
 
-## Requirements
+- **User**: `dbt` (password: `dbtPassword123`)
+- **Roles**: `TRANSFORM`, `REPORTER`
+- **Database**: `AIRBNB`
+- **Schemas**: `RAW`, `DEV`
+- **Tables**: `raw_listings`, `raw_hosts`, `raw_reviews`
 
-See `requirements.txt` for all dependencies. Key packages:
-- streamlit
-- cryptography (for key generation)
-- sqlalchemy (for Snowflake connection)
-- snowflake-sqlalchemy
+## Deployment
+
+### GitHub Actions
+
+The project includes a CI/CD pipeline that:
+1. Builds Docker images for amd64 and arm64
+2. Runs health checks and integration tests
+3. Pushes to `registry.nordquant.com/dbt-bootcamp-setup:latest`
+
+Required GitHub secrets:
+- `REGISTRY_USERNAME`
+- `REGISTRY_PASSWORD`
+
+See [.github/workflows/build-and-push.yml](.github/workflows/build-and-push.yml) for details.
+
+## Dependencies
+
+Main dependencies (pinned to major.minor versions):
+- `streamlit>=1.51,<1.52` - Web application framework
+- `sqlalchemy>=2.0,<2.1` - Database ORM
+- `snowflake-sqlalchemy>=1.7,<1.8` - Snowflake dialect
+- `snowflake-connector-python>=3.18,<3.19` - Snowflake driver
+- `pydantic>=2.12,<2.13` - Data validation
+- `urllib3>=2.5,<2.6` - HTTP client (required for Python 3.13)
+
+See [pyproject.toml](pyproject.toml) for full dependency list.
+
+## License
+
+This project is part of the dbt Zero to Hero Udemy course materials.
+
+## Support
+
+For issues or questions about:
+- **The application**: Check the logs in the Streamlit interface
+- **Docker deployment**: See [DOCKER.md](DOCKER.md)
+- **The dbt course**: Refer to the Udemy course materials


### PR DESCRIPTION
- Add drain_timeout input to build-and-push workflow (default: 600s)
- Update deployment to use new redeploy script from base-infra
- Fix health endpoint test to use /healthz
- Update README to mention zero-downtime deployments

Workflow can now be manually triggered with custom drain timeout for testing (e.g., 10 seconds instead of 10 minutes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)